### PR TITLE
Add `Japanese` as a supported language

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,5 +34,17 @@
     "contributors": [
       "754982406393430098"
     ]
+  },
+  {
+    "name": "ja-JP",
+    "nativeName": "日本語",
+    "wikiCode": null,
+    "discordCode": "ja",
+    "iso639": "ja",
+    "flag": "🇯🇵",
+    "default": false,
+    "contributors": [
+      "266103595949096960"
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds **Japanese** as a supported language for Filo.

**Note**: Translations from this language may be unreliable/accurate. Help us improve them if you find any errors!