### PR TITLE
Add `Català` as a supported language

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,5 +31,16 @@
     "contributors": [
       "754982406393430098"
     ]
+  },
+  {
+    "name": "ca-ES",
+    "nativeName": "Català",
+    "wikiCode": null,
+    "discordCode": null,
+    "flag": "🇸🇵",
+    "default": false,
+    "contributors": [
+      "661241315891085314"
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds **Català** as a supported language for Filo.